### PR TITLE
Populate remaining unused tokens with JTOK_UNASSIGNED_TOKEN in jtok_parse

### DIFF
--- a/src/jtok.c
+++ b/src/jtok.c
@@ -284,6 +284,13 @@ JTOK_PARSE_STATUS_t jtok_parse(const char *json, jtok_tkn_t *tkns, size_t size)
         }
         status = jtok_parse_object(&parser, 0);
     }
+
+  // Populates remaining unused tokens with JTOK_UNASSIGNED_TOKEN
+  // - Alex
+  for (int x = parser.toknext; x < size; x++) {
+    tkns[x].type = JTOK_UNASSIGNED_TOKEN;
+  }
+
     return status;
 }
 


### PR DESCRIPTION
Hey guys, 

This is my first dive into the JTOK library so forgive me if there's an existing method for this.

When iterating through an array of parsed tokens using a for loop, I ran into segmentation errors since I could not determine where the array ends.

There exists a JTOK type identifier known as `JTOK_UNASSIGNED_TOKEN`, which I assume is meant to identify the remaining unassigned portion of the token array. But `jtok_parse` does not automatically implement this, and the only place the index of the last meaningful token is stored is in the `parser.toknext` value, which goes out of scope by the time `jtok_parse` returns.

So I added 3 lines of code in the `jtok_parse()` method which populates the remaining (if any) tokens in the output array with `JTOK_UNASSIGNED_TOKEN` in their type field.

Let me know what you think.

Peace